### PR TITLE
feat: Add environment variable to control public registration

### DIFF
--- a/apps/dokploy/pages/register.tsx
+++ b/apps/dokploy/pages/register.tsx
@@ -278,8 +278,10 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 		};
 	}
 	const hasAdmin = await isAdminPresent();
+	const allowPublicRegistration =
+		process.env.DOKPLOY_ALLOW_PUBLIC_REGISTRATION === "true";
 
-	if (hasAdmin) {
+	if (hasAdmin && !allowPublicRegistration) {
 		return {
 			redirect: {
 				permanent: false,

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -103,6 +103,19 @@ const { handler, api } = betterAuth({
 									message: "User not found",
 								});
 							}
+						} else {
+							const allowPublicRegistration =
+								process.env.DOKPLOY_ALLOW_PUBLIC_REGISTRATION === "true";
+							if (!allowPublicRegistration) {
+								const isAdminPresent = await db.query.member.findFirst({
+									where: eq(schema.member.role, "owner"),
+								});
+								if (isAdminPresent) {
+									throw new APIError("BAD_REQUEST", {
+										message: "Admin is already created",
+									});
+								}
+							}
 						}
 					}
 				},


### PR DESCRIPTION
This change introduces a new environment variable, `DOKPLOY_ALLOW_PUBLIC_REGISTRATION`, to allow administrators of self-hosted instances to enable or disable public user registration.

- If `DOKPLOY_ALLOW_PUBLIC_REGISTRATION` is set to `'true'`, the `/register` page will be accessible to everyone, and new users can sign up.
- If this variable is `false` or not set, the application will maintain the default behavior of disabling the registration page after the first administrator is created.

This provides more flexibility for self-hosted deployments that may require open registration.