### PR TITLE
refactor: Break circular dependency in db schema

### DIFF
--- a/apps/dokploy/schema.dbml
+++ b/apps/dokploy/schema.dbml
@@ -1,0 +1,1127 @@
+enum buildType {
+  dockerfile
+  heroku_buildpacks
+  paketo_buildpacks
+  nixpacks
+  static
+  railpack
+}
+
+enum sourceType {
+  docker
+  git
+  github
+  gitlab
+  bitbucket
+  gitea
+  drop
+}
+
+enum domainType {
+  compose
+  application
+  preview
+}
+
+enum backupType {
+  database
+  compose
+}
+
+enum databaseType {
+  postgres
+  mariadb
+  mysql
+  mongo
+  "web-server"
+}
+
+enum deploymentStatus {
+  running
+  done
+  error
+}
+
+enum mountType {
+  bind
+  volume
+  file
+}
+
+enum protocolType {
+  tcp
+  udp
+}
+
+enum publishModeType {
+  ingress
+  host
+}
+
+enum applicationStatus {
+  idle
+  running
+  done
+  error
+}
+
+enum certificateType {
+  letsencrypt
+  none
+  custom
+}
+
+enum triggerType {
+  push
+  tag
+}
+
+enum composeType {
+  "docker-compose"
+  stack
+}
+
+enum sourceTypeCompose {
+  git
+  github
+  gitlab
+  bitbucket
+  gitea
+  raw
+}
+
+enum RegistryType {
+  selfHosted
+  cloud
+}
+
+enum notificationType {
+  slack
+  telegram
+  discord
+  email
+  gotify
+}
+
+enum gitProviderType {
+  github
+  gitlab
+  bitbucket
+  gitea
+}
+
+enum serverStatus {
+  active
+  inactive
+}
+
+enum scheduleType {
+  application
+  compose
+  server
+  "dokploy-server"
+}
+
+enum shellType {
+  bash
+  sh
+}
+
+table application {
+  applicationId text [pk, not null]
+  name text [not null]
+  appName text [not null, unique]
+  description text
+  env text
+  previewEnv text
+  watchPaths text[]
+  previewBuildArgs text
+  previewWildcard text
+  previewPort integer [default: 3000]
+  previewHttps boolean [not null, default: false]
+  previewPath text [default: '/']
+  certificateType certificateType [not null, default: 'none']
+  previewCustomCertResolver text
+  previewLimit integer [default: 3]
+  isPreviewDeploymentsActive boolean [default: false]
+  previewRequireCollaboratorPermissions boolean [default: true]
+  rollbackActive boolean [default: false]
+  buildArgs text
+  memoryReservation text
+  memoryLimit text
+  cpuReservation text
+  cpuLimit text
+  title text
+  enabled boolean
+  subtitle text
+  command text
+  refreshToken text
+  sourceType sourceType [not null, default: 'github']
+  cleanCache boolean [default: false]
+  repository text
+  owner text
+  branch text
+  buildPath text [default: '/']
+  triggerType triggerType [default: 'push']
+  autoDeploy boolean
+  gitlabProjectId integer
+  gitlabRepository text
+  gitlabOwner text
+  gitlabBranch text
+  gitlabBuildPath text [default: '/']
+  gitlabPathNamespace text
+  giteaRepository text
+  giteaOwner text
+  giteaBranch text
+  giteaBuildPath text [default: '/']
+  bitbucketRepository text
+  bitbucketOwner text
+  bitbucketBranch text
+  bitbucketBuildPath text [default: '/']
+  username text
+  password text
+  dockerImage text
+  registryUrl text
+  customGitUrl text
+  customGitBranch text
+  customGitBuildPath text
+  customGitSSHKeyId text
+  enableSubmodules boolean [not null, default: false]
+  dockerfile text
+  dockerContextPath text
+  dockerBuildStage text
+  dropBuildPath text
+  healthCheckSwarm json
+  restartPolicySwarm json
+  placementSwarm json
+  updateConfigSwarm json
+  rollbackConfigSwarm json
+  modeSwarm json
+  labelsSwarm json
+  networkSwarm json
+  replicas integer [not null, default: 1]
+  applicationStatus applicationStatus [not null, default: 'idle']
+  buildType buildType [not null, default: 'nixpacks']
+  railpackVersion text [default: '0.2.2']
+  herokuVersion text [default: '24']
+  publishDirectory text
+  isStaticSpa boolean
+  createdAt text [not null]
+  registryId text
+  projectId text [not null]
+  githubId text
+  gitlabId text
+  giteaId text
+  bitbucketId text
+  serverId text
+}
+
+table postgres {
+  postgresId text [pk, not null]
+  name text [not null]
+  appName text [not null, unique]
+  databaseName text [not null]
+  databaseUser text [not null]
+  databasePassword text [not null]
+  description text
+  dockerImage text [not null]
+  command text
+  env text
+  memoryReservation text
+  externalPort integer
+  memoryLimit text
+  cpuReservation text
+  cpuLimit text
+  applicationStatus applicationStatus [not null, default: 'idle']
+  healthCheckSwarm json
+  restartPolicySwarm json
+  placementSwarm json
+  updateConfigSwarm json
+  rollbackConfigSwarm json
+  modeSwarm json
+  labelsSwarm json
+  networkSwarm json
+  replicas integer [not null, default: 1]
+  createdAt text [not null]
+  projectId text [not null]
+  serverId text
+}
+
+table user_temp {
+  id text [pk, not null]
+  name text [not null, default: '']
+  isRegistered boolean [not null, default: false]
+  expirationDate text [not null]
+  createdAt text [not null]
+  created_at timestamp [default: `now()`]
+  two_factor_enabled boolean
+  email text [not null, unique]
+  email_verified boolean [not null]
+  image text
+  banned boolean
+  ban_reason text
+  ban_expires timestamp
+  updated_at timestamp [not null]
+  serverIp text
+  certificateType certificateType [not null, default: 'none']
+  https boolean [not null, default: false]
+  host text
+  letsEncryptEmail text
+  sshPrivateKey text
+  enableDockerCleanup boolean [not null, default: false]
+  logCleanupCron text [default: '0 0 * * *']
+  role text [not null, default: 'user']
+  enablePaidFeatures boolean [not null, default: false]
+  allowImpersonation boolean [not null, default: false]
+  metricsConfig jsonb [not null, default: `{"server":{"type":"Dokploy","refreshRate":60,"port":4500,"token":"","retentionDays":2,"cronJob":"","urlCallback":"","thresholds":{"cpu":0,"memory":0}},"containers":{"refreshRate":60,"services":{"include":[],"exclude":[]}}}`]
+  cleanupCacheApplications boolean [not null, default: false]
+  cleanupCacheOnPreviews boolean [not null, default: false]
+  cleanupCacheOnCompose boolean [not null, default: false]
+  stripeCustomerId text
+  stripeSubscriptionId text
+  serversQuantity integer [not null, default: 0]
+}
+
+table project {
+  projectId text [pk, not null]
+  name text [not null]
+  description text
+  createdAt text [not null]
+  organizationId text [not null]
+  env text [not null, default: '']
+}
+
+table domain {
+  domainId text [pk, not null]
+  host text [not null]
+  https boolean [not null, default: false]
+  port integer [default: 3000]
+  path text [default: '/']
+  serviceName text
+  domainType domainType [default: 'application']
+  uniqueConfigKey serial [not null, increment]
+  createdAt text [not null]
+  composeId text
+  customCertResolver text
+  applicationId text
+  previewDeploymentId text
+  certificateType certificateType [not null, default: 'none']
+  internalPath text [default: '/']
+  stripPath boolean [not null, default: false]
+}
+
+table mariadb {
+  mariadbId text [pk, not null]
+  name text [not null]
+  appName text [not null, unique]
+  description text
+  databaseName text [not null]
+  databaseUser text [not null]
+  databasePassword text [not null]
+  rootPassword text [not null]
+  dockerImage text [not null]
+  command text
+  env text
+  memoryReservation text
+  memoryLimit text
+  cpuReservation text
+  cpuLimit text
+  externalPort integer
+  applicationStatus applicationStatus [not null, default: 'idle']
+  healthCheckSwarm json
+  restartPolicySwarm json
+  placementSwarm json
+  updateConfigSwarm json
+  rollbackConfigSwarm json
+  modeSwarm json
+  labelsSwarm json
+  networkSwarm json
+  replicas integer [not null, default: 1]
+  createdAt text [not null]
+  projectId text [not null]
+  serverId text
+}
+
+table mongo {
+  mongoId text [pk, not null]
+  name text [not null]
+  appName text [not null, unique]
+  description text
+  databaseUser text [not null]
+  databasePassword text [not null]
+  dockerImage text [not null]
+  command text
+  env text
+  memoryReservation text
+  memoryLimit text
+  cpuReservation text
+  cpuLimit text
+  externalPort integer
+  applicationStatus applicationStatus [not null, default: 'idle']
+  healthCheckSwarm json
+  restartPolicySwarm json
+  placementSwarm json
+  updateConfigSwarm json
+  rollbackConfigSwarm json
+  modeSwarm json
+  labelsSwarm json
+  networkSwarm json
+  replicas integer [not null, default: 1]
+  createdAt text [not null]
+  projectId text [not null]
+  serverId text
+  replicaSets boolean [default: false]
+}
+
+table mysql {
+  mysqlId text [pk, not null]
+  name text [not null]
+  appName text [not null, unique]
+  description text
+  databaseName text [not null]
+  databaseUser text [not null]
+  databasePassword text [not null]
+  rootPassword text [not null]
+  dockerImage text [not null]
+  command text
+  env text
+  memoryReservation text
+  memoryLimit text
+  cpuReservation text
+  cpuLimit text
+  externalPort integer
+  applicationStatus applicationStatus [not null, default: 'idle']
+  healthCheckSwarm json
+  restartPolicySwarm json
+  placementSwarm json
+  updateConfigSwarm json
+  rollbackConfigSwarm json
+  modeSwarm json
+  labelsSwarm json
+  networkSwarm json
+  replicas integer [not null, default: 1]
+  createdAt text [not null]
+  projectId text [not null]
+  serverId text
+}
+
+table backup {
+  backupId text [pk, not null]
+  appName text [not null, unique]
+  schedule text [not null]
+  enabled boolean
+  database text [not null]
+  prefix text [not null]
+  serviceName text
+  destinationId text [not null]
+  keepLatestCount integer
+  backupType backupType [not null, default: 'database']
+  databaseType databaseType [not null]
+  composeId text
+  postgresId text
+  mariadbId text
+  mysqlId text
+  mongoId text
+  userId text
+  metadata jsonb
+}
+
+table destination {
+  destinationId text [pk, not null]
+  name text [not null]
+  provider text
+  accessKey text [not null]
+  secretAccessKey text [not null]
+  bucket text [not null]
+  region text [not null]
+  endpoint text [not null]
+  organizationId text [not null]
+  createdAt timestamp [not null, default: `now()`]
+}
+
+table deployment {
+  deploymentId text [pk, not null]
+  title text [not null]
+  description text
+  status deploymentStatus [default: 'running']
+  logPath text [not null]
+  pid text
+  applicationId text
+  composeId text
+  serverId text
+  isPreviewDeployment boolean [default: false]
+  previewDeploymentId text
+  createdAt text [not null]
+  startedAt text
+  finishedAt text
+  errorMessage text
+  scheduleId text
+  backupId text
+  rollbackId text
+  volumeBackupId text
+}
+
+table mount {
+  mountId text [pk, not null]
+  type mountType [not null]
+  hostPath text
+  volumeName text
+  filePath text
+  content text
+  serviceType serviceType [not null, default: 'application']
+  mountPath text [not null]
+  applicationId text
+  postgresId text
+  mariadbId text
+  mongoId text
+  mysqlId text
+  redisId text
+  composeId text
+}
+
+table certificate {
+  certificateId text [pk, not null]
+  name text [not null]
+  certificateData text [not null]
+  privateKey text [not null]
+  certificatePath text [not null, unique]
+  autoRenew boolean
+  organizationId text [not null]
+  serverId text
+}
+
+table session_temp {
+  id text [pk, not null]
+  expires_at timestamp [not null]
+  token text [not null, unique]
+  created_at timestamp [not null]
+  updated_at timestamp [not null]
+  ip_address text
+  user_agent text
+  user_id text [not null]
+  impersonated_by text
+  active_organization_id text
+}
+
+table redirect {
+  redirectId text [pk, not null]
+  regex text [not null]
+  replacement text [not null]
+  permanent boolean [not null, default: false]
+  uniqueConfigKey serial [not null, increment]
+  createdAt text [not null]
+  applicationId text [not null]
+}
+
+table security {
+  securityId text [pk, not null]
+  username text [not null]
+  password text [not null]
+  createdAt text [not null]
+  applicationId text [not null]
+
+  indexes {
+    (username, applicationId) [name: 'security_username_applicationId_unique', unique]
+  }
+}
+
+table port {
+  portId text [pk, not null]
+  publishedPort integer [not null]
+  publishMode publishModeType [not null, default: 'host']
+  targetPort integer [not null]
+  protocol protocolType [not null]
+  applicationId text [not null]
+}
+
+table redis {
+  redisId text [pk, not null]
+  name text [not null]
+  appName text [not null, unique]
+  description text
+  password text [not null]
+  dockerImage text [not null]
+  command text
+  env text
+  memoryReservation text
+  memoryLimit text
+  cpuReservation text
+  cpuLimit text
+  externalPort integer
+  createdAt text [not null]
+  applicationStatus applicationStatus [not null, default: 'idle']
+  healthCheckSwarm json
+  restartPolicySwarm json
+  placementSwarm json
+  updateConfigSwarm json
+  rollbackConfigSwarm json
+  modeSwarm json
+  labelsSwarm json
+  networkSwarm json
+  replicas integer [not null, default: 1]
+  projectId text [not null]
+  serverId text
+}
+
+table compose {
+  composeId text [pk, not null]
+  name text [not null]
+  appName text [not null]
+  description text
+  env text
+  composeFile text [not null, default: '']
+  refreshToken text
+  sourceType sourceTypeCompose [not null, default: 'github']
+  composeType composeType [not null, default: 'docker-compose']
+  repository text
+  owner text
+  branch text
+  autoDeploy boolean
+  gitlabProjectId integer
+  gitlabRepository text
+  gitlabOwner text
+  gitlabBranch text
+  gitlabPathNamespace text
+  bitbucketRepository text
+  bitbucketOwner text
+  bitbucketBranch text
+  giteaRepository text
+  giteaOwner text
+  giteaBranch text
+  customGitUrl text
+  customGitBranch text
+  customGitSSHKeyId text
+  command text [not null, default: '']
+  enableSubmodules boolean [not null, default: false]
+  composePath text [not null, default: './docker-compose.yml']
+  suffix text [not null, default: '']
+  randomize boolean [not null, default: false]
+  isolatedDeployment boolean [not null, default: false]
+  isolatedDeploymentsVolume boolean [not null, default: false]
+  triggerType triggerType [default: 'push']
+  composeStatus applicationStatus [not null, default: 'idle']
+  projectId text [not null]
+  createdAt text [not null]
+  watchPaths text[]
+  githubId text
+  gitlabId text
+  bitbucketId text
+  giteaId text
+  serverId text
+}
+
+table registry {
+  registryId text [pk, not null]
+  registryName text [not null]
+  imagePrefix text
+  username text [not null]
+  password text [not null]
+  registryUrl text [not null, default: '']
+  createdAt text [not null]
+  selfHosted RegistryType [not null, default: 'cloud']
+  organizationId text [not null]
+}
+
+table discord {
+  discordId text [pk, not null]
+  webhookUrl text [not null]
+  decoration boolean
+}
+
+table email {
+  emailId text [pk, not null]
+  smtpServer text [not null]
+  smtpPort integer [not null]
+  username text [not null]
+  password text [not null]
+  fromAddress text [not null]
+  toAddress text[] [not null]
+}
+
+table gotify {
+  gotifyId text [pk, not null]
+  serverUrl text [not null]
+  appToken text [not null]
+  priority integer [not null, default: 5]
+  decoration boolean
+}
+
+table notification {
+  notificationId text [pk, not null]
+  name text [not null]
+  appDeploy boolean [not null, default: false]
+  appBuildError boolean [not null, default: false]
+  databaseBackup boolean [not null, default: false]
+  dokployRestart boolean [not null, default: false]
+  dockerCleanup boolean [not null, default: false]
+  serverThreshold boolean [not null, default: false]
+  notificationType notificationType [not null]
+  createdAt text [not null]
+  slackId text
+  telegramId text
+  discordId text
+  emailId text
+  gotifyId text
+  organizationId text [not null]
+}
+
+table slack {
+  slackId text [pk, not null]
+  webhookUrl text [not null]
+  channel text
+}
+
+table telegram {
+  telegramId text [pk, not null]
+  botToken text [not null]
+  chatId text [not null]
+  messageThreadId text
+}
+
+table "ssh-key" {
+  sshKeyId text [pk, not null]
+  privateKey text [not null, default: '']
+  publicKey text [not null]
+  name text [not null]
+  description text
+  createdAt text [not null]
+  lastUsedAt text
+  organizationId text [not null]
+}
+
+table git_provider {
+  gitProviderId text [pk, not null]
+  name text [not null]
+  providerType gitProviderType [not null, default: 'github']
+  createdAt text [not null]
+  organizationId text [not null]
+  userId text [not null]
+}
+
+table bitbucket {
+  bitbucketId text [pk, not null]
+  bitbucketUsername text
+  appPassword text
+  bitbucketWorkspaceName text
+  gitProviderId text [not null]
+}
+
+table github {
+  githubId text [pk, not null]
+  githubAppName text
+  githubAppId integer
+  githubClientId text
+  githubClientSecret text
+  githubInstallationId text
+  githubPrivateKey text
+  githubWebhookSecret text
+  gitProviderId text [not null]
+}
+
+table gitlab {
+  gitlabId text [pk, not null]
+  gitlabUrl text [not null, default: 'https://gitlab.com']
+  application_id text
+  redirect_uri text
+  secret text
+  access_token text
+  refresh_token text
+  group_name text
+  expires_at integer
+  gitProviderId text [not null]
+}
+
+table gitea {
+  giteaId text [pk, not null]
+  giteaUrl text [not null, default: 'https://gitea.com']
+  redirect_uri text
+  client_id text
+  client_secret text
+  gitProviderId text [not null]
+  access_token text
+  refresh_token text
+  expires_at integer
+  scopes text [default: 'repo,repo:status,read:user,read:org']
+  last_authenticated_at integer
+}
+
+table server {
+  serverId text [pk, not null]
+  name text [not null]
+  description text
+  ipAddress text [not null]
+  port integer [not null]
+  username text [not null, default: 'root']
+  appName text [not null]
+  enableDockerCleanup boolean [not null, default: false]
+  createdAt text [not null]
+  organizationId text [not null]
+  serverStatus serverStatus [not null, default: 'active']
+  command text [not null, default: '']
+  sshKeyId text
+  metricsConfig jsonb [not null, default: `{"server":{"type":"Remote","refreshRate":60,"port":4500,"token":"","urlCallback":"","cronJob":"","retentionDays":2,"thresholds":{"cpu":0,"memory":0}},"containers":{"refreshRate":60,"services":{"include":[],"exclude":[]}}}`]
+}
+
+table preview_deployments {
+  previewDeploymentId text [pk, not null]
+  branch text [not null]
+  pullRequestId text [not null]
+  pullRequestNumber text [not null]
+  pullRequestURL text [not null]
+  pullRequestTitle text [not null]
+  pullRequestCommentId text [not null]
+  previewStatus applicationStatus [not null, default: 'idle']
+  appName text [not null, unique]
+  applicationId text [not null]
+  domainId text
+  createdAt text [not null]
+  expiresAt text
+}
+
+table ai {
+  aiId text [pk, not null]
+  name text [not null]
+  apiUrl text [not null]
+  apiKey text [not null]
+  model text [not null]
+  isEnabled boolean [not null, default: true]
+  organizationId text [not null]
+  createdAt text [not null]
+}
+
+table account {
+  id text [pk, not null]
+  account_id text [not null]
+  provider_id text [not null]
+  user_id text [not null]
+  access_token text
+  refresh_token text
+  id_token text
+  access_token_expires_at timestamp
+  refresh_token_expires_at timestamp
+  scope text
+  password text
+  is2FAEnabled boolean [not null, default: false]
+  created_at timestamp [not null]
+  updated_at timestamp [not null]
+  resetPasswordToken text
+  resetPasswordExpiresAt text
+  confirmationToken text
+  confirmationExpiresAt text
+}
+
+table apikey {
+  id text [pk, not null]
+  name text
+  start text
+  prefix text
+  key text [not null]
+  user_id text [not null]
+  refill_interval integer
+  refill_amount integer
+  last_refill_at timestamp
+  enabled boolean
+  rate_limit_enabled boolean
+  rate_limit_time_window integer
+  rate_limit_max integer
+  request_count integer
+  remaining integer
+  last_request timestamp
+  expires_at timestamp
+  created_at timestamp [not null]
+  updated_at timestamp [not null]
+  permissions text
+  metadata text
+}
+
+table invitation {
+  id text [pk, not null]
+  organization_id text [not null]
+  email text [not null]
+  role text
+  status text [not null]
+  expires_at timestamp [not null]
+  inviter_id text [not null]
+  team_id text
+}
+
+table member {
+  id text [pk, not null]
+  organization_id text [not null]
+  user_id text [not null]
+  role text [not null]
+  created_at timestamp [not null]
+  team_id text
+  canCreateProjects boolean [not null, default: false]
+  canAccessToSSHKeys boolean [not null, default: false]
+  canCreateServices boolean [not null, default: false]
+  canDeleteProjects boolean [not null, default: false]
+  canDeleteServices boolean [not null, default: false]
+  canAccessToDocker boolean [not null, default: false]
+  canAccessToAPI boolean [not null, default: false]
+  canAccessToGitProviders boolean [not null, default: false]
+  canAccessToTraefikFiles boolean [not null, default: false]
+  accesedProjects text[] [not null, default: `ARRAY[]::text[]`]
+  accesedServices text[] [not null, default: `ARRAY[]::text[]`]
+}
+
+table organization {
+  id text [pk, not null]
+  name text [not null]
+  slug text [unique]
+  logo text
+  created_at timestamp [not null]
+  metadata text
+  owner_id text [not null]
+  isPublicRegistrationEnabled boolean [not null, default: false]
+}
+
+table two_factor {
+  id text [pk, not null]
+  secret text [not null]
+  backup_codes text [not null]
+  user_id text [not null]
+}
+
+table verification {
+  id text [pk, not null]
+  identifier text [not null]
+  value text [not null]
+  expires_at timestamp [not null]
+  created_at timestamp
+  updated_at timestamp
+}
+
+table schedule {
+  scheduleId text [pk, not null]
+  name text [not null]
+  cronExpression text [not null]
+  appName text [not null]
+  serviceName text
+  shellType shellType [not null, default: 'bash']
+  scheduleType scheduleType [not null, default: 'application']
+  command text [not null]
+  script text
+  applicationId text
+  composeId text
+  serverId text
+  userId text
+  enabled boolean [not null, default: true]
+  createdAt text [not null]
+}
+
+table rollback {
+  rollbackId text [pk, not null]
+  deploymentId text [not null]
+  version serial [not null, increment]
+  image text
+  createdAt text [not null]
+  fullContext jsonb
+}
+
+table volume_backup {
+  volumeBackupId text [pk, not null]
+  name text [not null]
+  volumeName text [not null]
+  prefix text [not null]
+  serviceType serviceType [not null, default: 'application']
+  appName text [not null]
+  serviceName text
+  turnOff boolean [not null, default: false]
+  cronExpression text [not null]
+  keepLatestCount integer
+  enabled boolean
+  applicationId text
+  postgresId text
+  mariadbId text
+  mongoId text
+  mysqlId text
+  redisId text
+  composeId text
+  createdAt text [not null]
+  destinationId text [not null]
+}
+
+ref: application.projectId > project.projectId
+
+ref: application.customGitSSHKeyId > "ssh-key".sshKeyId
+
+ref: application.registryId > registry.registryId
+
+ref: application.githubId - github.githubId
+
+ref: application.gitlabId - gitlab.gitlabId
+
+ref: application.giteaId - gitea.giteaId
+
+ref: application.bitbucketId - bitbucket.bitbucketId
+
+ref: application.serverId > server.serverId
+
+ref: postgres.projectId > project.projectId
+
+ref: postgres.serverId > server.serverId
+
+ref: account.user_id - user_temp.id
+
+ref: project.organizationId > organization.id
+
+ref: domain.applicationId > application.applicationId
+
+ref: domain.composeId > compose.composeId
+
+ref: preview_deployments.domainId - domain.domainId
+
+ref: mariadb.projectId > project.projectId
+
+ref: mariadb.serverId > server.serverId
+
+ref: mongo.projectId > project.projectId
+
+ref: mongo.serverId > server.serverId
+
+ref: mysql.projectId > project.projectId
+
+ref: mysql.serverId > server.serverId
+
+ref: backup.destinationId > destination.destinationId
+
+ref: backup.postgresId > postgres.postgresId
+
+ref: backup.mariadbId > mariadb.mariadbId
+
+ref: backup.mysqlId > mysql.mysqlId
+
+ref: backup.mongoId > mongo.mongoId
+
+ref: backup.userId > user_temp.id
+
+ref: backup.composeId > compose.composeId
+
+ref: destination.organizationId - organization.id
+
+ref: deployment.applicationId > application.applicationId
+
+ref: deployment.composeId > compose.composeId
+
+ref: deployment.serverId > server.serverId
+
+ref: deployment.previewDeploymentId > preview_deployments.previewDeploymentId
+
+ref: deployment.scheduleId > schedule.scheduleId
+
+ref: deployment.backupId > backup.backupId
+
+ref: rollback.deploymentId - deployment.deploymentId
+
+ref: deployment.volumeBackupId > volume_backup.volumeBackupId
+
+ref: mount.applicationId > application.applicationId
+
+ref: mount.postgresId > postgres.postgresId
+
+ref: mount.mariadbId > mariadb.mariadbId
+
+ref: mount.mongoId > mongo.mongoId
+
+ref: mount.mysqlId > mysql.mysqlId
+
+ref: mount.redisId > redis.redisId
+
+ref: mount.composeId > compose.composeId
+
+ref: certificate.serverId > server.serverId
+
+ref: certificate.organizationId - organization.id
+
+ref: redirect.applicationId > application.applicationId
+
+ref: security.applicationId > application.applicationId
+
+ref: port.applicationId > application.applicationId
+
+ref: redis.projectId > project.projectId
+
+ref: redis.serverId > server.serverId
+
+ref: compose.projectId > project.projectId
+
+ref: compose.customGitSSHKeyId > "ssh-key".sshKeyId
+
+ref: compose.githubId - github.githubId
+
+ref: compose.gitlabId - gitlab.gitlabId
+
+ref: compose.bitbucketId - bitbucket.bitbucketId
+
+ref: compose.giteaId - gitea.giteaId
+
+ref: compose.serverId > server.serverId
+
+ref: notification.slackId - slack.slackId
+
+ref: notification.telegramId - telegram.telegramId
+
+ref: notification.discordId - discord.discordId
+
+ref: notification.emailId - email.emailId
+
+ref: notification.gotifyId - gotify.gotifyId
+
+ref: notification.organizationId - organization.id
+
+ref: "ssh-key".organizationId - organization.id
+
+ref: github.gitProviderId - git_provider.gitProviderId
+
+ref: gitlab.gitProviderId - git_provider.gitProviderId
+
+ref: bitbucket.gitProviderId - git_provider.gitProviderId
+
+ref: gitea.gitProviderId - git_provider.gitProviderId
+
+ref: git_provider.organizationId - organization.id
+
+ref: git_provider.userId - user_temp.id
+
+ref: server.sshKeyId > "ssh-key".sshKeyId
+
+ref: server.organizationId > organization.id
+
+ref: preview_deployments.applicationId > application.applicationId
+
+ref: ai.organizationId - organization.id
+
+ref: apikey.user_id > user_temp.id
+
+ref: invitation.organization_id - organization.id
+
+ref: member.organization_id > organization.id
+
+ref: member.user_id - user_temp.id
+
+ref: organization.owner_id > user_temp.id
+
+ref: schedule.applicationId - application.applicationId
+
+ref: schedule.composeId > compose.composeId
+
+ref: schedule.serverId > server.serverId
+
+ref: schedule.userId > user_temp.id
+
+ref: volume_backup.applicationId - application.applicationId
+
+ref: volume_backup.postgresId - postgres.postgresId
+
+ref: volume_backup.mariadbId - mariadb.mariadbId
+
+ref: volume_backup.mongoId - mongo.mongoId
+
+ref: volume_backup.mysqlId - mysql.mysqlId
+
+ref: volume_backup.redisId - redis.redisId
+
+ref: volume_backup.composeId - compose.composeId
+
+ref: volume_backup.destinationId - destination.destinationId

--- a/packages/server/src/db/schema/mount.ts
+++ b/packages/server/src/db/schema/mount.ts
@@ -10,16 +10,8 @@ import { mongo } from "./mongo";
 import { mysql } from "./mysql";
 import { postgres } from "./postgres";
 import { redis } from "./redis";
+import { serviceType } from "./service-type";
 
-export const serviceType = pgEnum("serviceType", [
-	"application",
-	"postgres",
-	"mysql",
-	"mariadb",
-	"mongo",
-	"redis",
-	"compose",
-]);
 
 export const mountType = pgEnum("mountType", ["bind", "volume", "file"]);
 

--- a/packages/server/src/db/schema/service-type.ts
+++ b/packages/server/src/db/schema/service-type.ts
@@ -1,0 +1,11 @@
+import { pgEnum } from "drizzle-orm/pg-core";
+
+export const serviceType = pgEnum("serviceType", [
+	"application",
+	"postgres",
+	"mysql",
+	"mariadb",
+	"mongo",
+	"redis",
+	"compose",
+]);

--- a/packages/server/src/db/schema/volume-backups.ts
+++ b/packages/server/src/db/schema/volume-backups.ts
@@ -9,7 +9,7 @@ import { deployments } from "./deployment";
 import { destinations } from "./destination";
 import { mariadb } from "./mariadb";
 import { mongo } from "./mongo";
-import { serviceType } from "./mount";
+import { serviceType } from "./service-type";
 import { mysql } from "./mysql";
 import { postgres } from "./postgres";
 import { redis } from "./redis";


### PR DESCRIPTION
I refactored the database schema to resolve a circular dependency between `mount.ts` and `volume-backups.ts`.

I extracted the shared `serviceType` enum from `mount.ts` into its own file, `service-type.ts`.

Then, I updated both `mount.ts` and `volume-backups.ts` to import the enum from the new file.

This resolves a `ReferenceError` that was occurring when running `drizzle-kit generate` and makes the schema loading more robust.