### PR TITLE
fix: Run database migrations on application start

### DIFF
--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -6,7 +6,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "npm run build-server && npm run build-next",
-		"start": "node -r dotenv/config dist/server.mjs",
+		"start": "pnpm run migration:run && node -r dotenv/config dist/server.mjs",
 		"build-server": "tsx esbuild.config.ts",
 		"build-next": "next build",
 		"setup": "tsx -r dotenv/config setup.ts && sleep 5 && pnpm run migration:run",


### PR DESCRIPTION
This commit fixes a critical bug where the application would fail with a 400 error on a fresh installation due to an incomplete database schema.

The root cause was that the Docker container's start command (`pnpm start`) did not execute the database migrations. This meant that any schema changes, like the addition of the `isPublicRegistrationEnabled` column, were not being applied to the database.

To fix this, the `start` script in `apps/dokploy/package.json` has been modified to first run the `migration:run` script before starting the application server. This ensures that the database schema is always up-to-date when the application starts.

This commit also includes a previous fix that resolved a circular dependency in the Drizzle schema definition, which was discovered during the investigation of this issue.