### PR TITLE
fix: Generate random NEXTAUTH_SECRET in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,11 +135,11 @@ install_dokploy() {
     echo "Creating .env.production file..."
     cd "$DOKPLOY_SRC_DIR"
     if [ ! -f ".env.production" ]; then
-        cat << 'EOF' > .env.production
+cat << EOF > .env.production
 NODE_ENV=production
 DATABASE_URL=postgresql://dokploy:amukds4wi9001583845717ad2@dokploy-postgres:5432/dokploy
 REDIS_URL=redis://dokploy-redis:6379
-NEXTAUTH_SECRET=your-secret-key-here
+NEXTAUTH_SECRET=$(openssl rand -hex 32)
 NEXTAUTH_URL=http://localhost:3000
 EOF
         echo ".env.production file created"


### PR DESCRIPTION
This commit fixes a critical authentication issue that caused a 400 error on fresh installations.

The previous `install.sh` script used a static placeholder value for `NEXTAUTH_SECRET`. This caused the application's authentication system to fail, leading to `UNAUTHORIZED` errors from the tRPC API.

The script has been updated to use `openssl rand -hex 32` to generate a secure, random `NEXTAUTH_SECRET` and write it to the `.env.production` file during installation.

This ensures that the application starts with a valid, unique secret, allowing the authentication system to initialize correctly. This commit builds upon the previous fixes that ensure database migrations are run correctly.