### PR TITLE
fix: Make getPublicRegistrationStatus a public procedure

### DIFF
--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -721,7 +721,13 @@ export const settingsRouter = createTRPCRouter({
 		return { status: "not_cloud" };
 	}),
 
-	getPublicRegistrationStatus: protectedProcedure.query(async ({ ctx }) => {
+	getPublicRegistrationStatus: publicProcedure.query(async ({ ctx }) => {
+		if (!ctx.session) {
+			// If there is no session, it means it's a fresh installation
+			// and we should allow the first user to register.
+			const admin = await db.query.organization.findFirst();
+			return { isPublicRegistrationEnabled: !admin };
+		}
 		const { isPublicRegistrationEnabled } = await getPublicRegistrationStatus(
 			ctx.session.activeOrganizationId,
 		);


### PR DESCRIPTION
This commit fixes a critical authentication bug that caused a 400 error on fresh installations. The `getPublicRegistrationStatus` tRPC endpoint was incorrectly defined as a `protectedProcedure`, which requires authentication.

On a fresh install, no user is authenticated, so this check would always fail, leading to a `TRPCError: UNAUTHORIZED` error and preventing the initial registration page from loading.

The procedure has been changed to a `publicProcedure`. It now includes logic to handle the case where no user session exists. If there is no session, it checks for the existence of an organization. If none exists, it allows public registration so the first admin user can be created. This resolves the 400 error and allows the application to be set up correctly.