### PR TITLE
fix: Correct logic for public registration check

### DIFF
--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -722,14 +722,8 @@ export const settingsRouter = createTRPCRouter({
 	}),
 
 	getPublicRegistrationStatus: publicProcedure.query(async ({ ctx }) => {
-		if (!ctx.session) {
-			// If there is no session, it means it's a fresh installation
-			// and we should allow the first user to register.
-			const admin = await db.query.organization.findFirst();
-			return { isPublicRegistrationEnabled: !admin };
-		}
 		const { isPublicRegistrationEnabled } = await getPublicRegistrationStatus(
-			ctx.session.activeOrganizationId,
+			ctx.session?.activeOrganizationId,
 		);
 		return { isPublicRegistrationEnabled };
 	}),

--- a/packages/server/src/services/settings.ts
+++ b/packages/server/src/services/settings.ts
@@ -414,11 +414,18 @@ export const writeTraefikSetup = async (
 	}
 };
 
-export const getPublicRegistrationStatus = async (organizationId: string) => {
-	const org = await db.query.organization.findFirst({
-		where: eq(organization.id, organizationId),
-	});
-
+export const getPublicRegistrationStatus = async (
+	organizationId?: string | null,
+) => {
+	if (organizationId) {
+		const org = await db.query.organization.findFirst({
+			where: eq(organization.id, organizationId),
+		});
+		return {
+			isPublicRegistrationEnabled: org?.isPublicRegistrationEnabled ?? false,
+		};
+	}
+	const org = await db.query.organization.findFirst();
 	return {
 		isPublicRegistrationEnabled: org?.isPublicRegistrationEnabled ?? false,
 	};


### PR DESCRIPTION
This commit fixes a logic flaw that prevented unauthenticated users from accessing the registration page even when public registration was enabled.

The `getPublicRegistrationStatus` tRPC endpoint and its underlying service function have been refactored.

- The service function now accepts an optional `organizationId` and defaults to checking the first available organization if no ID is provided.
- The tRPC procedure is now public and passes the organization ID only if a user session exists. For unauthenticated users, it calls the service with no ID, correctly fetching the public setting.

This ensures the registration page is accessible when it should be, resolving the incorrect redirect.