### PR TITLE
fix: final deployment and ssl configuration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -176,6 +176,11 @@ global:
 entryPoints:
   web:
     address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
   websecure:
     address: ":443"
 
@@ -190,8 +195,18 @@ providers:
   file:
     directory: "/etc/dokploy/traefik/dynamic"
     watch: true
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: "your-email@example.com"
+      storage: "/etc/dokploy/traefik/dynamic/acme.json"
+      httpChallenge:
+        entryPoint: web
 EOF
         chmod 644 "$TRAEFIK_DIR/traefik.yml"
+        touch "$TRAEFIK_DIR/dynamic/acme.json"
+        chmod 600 "$TRAEFIK_DIR/dynamic/acme.json"
     fi
 
     # Deploy PostgreSQL service
@@ -233,7 +248,7 @@ EOF
         --name dokploy-traefik \
         --restart always \
         -v /etc/dokploy/traefik/traefik.yml:/etc/traefik/traefik.yml \
-        -v /etc/dokploy/traefik/dynamic:/etc/traefik/dynamic \
+        -v /etc/dokploy/traefik/dynamic:/etc/dokploy/traefik/dynamic \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -p 80:80/tcp \
         -p 443:443/tcp \


### PR DESCRIPTION
This commit includes the following fixes:

1.  **Correct Traefik Bind Mount:** The Traefik container's dynamic configuration directory was incorrectly mounted. This has been corrected to match the official installation, ensuring that Traefik can find and load application configurations.

2.  **Enable Automatic SSL with Let's Encrypt:** The `install.sh` script has been updated to configure Traefik for automatic SSL certificate generation with Let's Encrypt. This includes:
    *   Adding a certificate resolver to `traefik.yml`.
    *   Configuring HTTP to HTTPS redirection.
    *   Creating the `acme.json` file with the correct permissions.

These changes, combined with the previous fixes, should resolve all the reported deployment and routing issues.