### PR TITLE
fix(routing): Always add traefik network label to deployments

### DIFF
--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -250,10 +250,8 @@ export const addDomainToCompose = async (
 				labels.unshift("traefik.enable=true");
 			}
 			labels.unshift(...httpLabels);
-			if (!compose.isolatedDeployment) {
-				if (!labels.includes("traefik.docker.network=dokploy-network")) {
-					labels.unshift("traefik.docker.network=dokploy-network");
-				}
+			if (!labels.includes("traefik.docker.network=dokploy-network")) {
+				labels.unshift("traefik.docker.network=dokploy-network");
 			}
 		}
 


### PR DESCRIPTION
This fixes a bug where applications deployed with a custom domain would result in a 404 error when using isolated deployments.

The root cause was that the `traefik.docker.network=dokploy-network` label was not being added to services when `isolatedDeployment` was true. Traefik is configured to only discover services on the `dokploy-network`, so it was ignoring these isolated services, even when their networks were connected to the Traefik container.

This change removes the conditional logic and ensures the `traefik.docker.network` label is always added to all services with domains, allowing Traefik to correctly discover and route traffic to them regardless of the deployment mode.