### PR TITLE
fix(routing): Ensure all deployments are attached to the main Traefik…

### DIFF
--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -255,18 +255,14 @@ export const addDomainToCompose = async (
 			}
 		}
 
-		if (!compose.isolatedDeployment) {
-			// Add the dokploy-network to the service
-			result.services[serviceName].networks = addDokployNetworkToService(
-				result.services[serviceName].networks,
-			);
-		}
+		// Add the dokploy-network to the service
+		result.services[serviceName].networks = addDokployNetworkToService(
+			result.services[serviceName].networks,
+		);
 	}
 
 	// Add dokploy-network to the root of the compose file
-	if (!compose.isolatedDeployment) {
-		result.networks = addDokployNetworkToRoot(result.networks);
-	}
+	result.networks = addDokployNetworkToRoot(result.networks);
 
 	return result;
 };


### PR DESCRIPTION
… network

This commit fixes a critical bug that caused applications with custom domains to return a 404 error. The previous fix was insufficient because the issue was rooted in a flawed network isolation mechanism.

The `isolatedDeployment` feature, while creating separate networks for applications, failed to correctly configure them for Traefik, which is hard-coded to only monitor the `dokploy-network`.

This more comprehensive fix removes all conditional network logic related to `isolatedDeployment` within the compose file generation. By doing so, it ensures that every deployed application, regardless of its configuration, is attached to the `dokploy-network` and has the correct labels for Traefik to discover and route traffic to it. This effectively bypasses the broken network isolation feature in favor of a stable and consistent routing behavior.